### PR TITLE
open file when creating github config

### DIFF
--- a/gitmine/commands/config.py
+++ b/gitmine/commands/config.py
@@ -52,6 +52,7 @@ def config_command(ctx: click.Context, prop: str, value: str) -> None:
 def get_or_create_github_config() -> GithubConfig:
     """ Get Github Config info if it's already been written to disk,
         otherwise create an empty config to be filled in later.
+        Create a credentials folder if it does not exist
     """
 
     github_config = GithubConfig()
@@ -61,5 +62,7 @@ def get_or_create_github_config() -> GithubConfig:
             for line in handle:
                 prop, value = line.split()
                 github_config.set_prop(prop, value)
-
+    else:
+        open(GITHUB_CREDENTIALS_PATH, 'a') 
+        
     return github_config

--- a/gitmine/commands/config.py
+++ b/gitmine/commands/config.py
@@ -1,4 +1,5 @@
 import click
+from pathlib import Path
 
 from gitmine.constants import GITHUB_CREDENTIALS_PATH
 
@@ -63,6 +64,6 @@ def get_or_create_github_config() -> GithubConfig:
                 prop, value = line.split()
                 github_config.set_prop(prop, value)
     else:
-        open(GITHUB_CREDENTIALS_PATH, 'a') 
+        Path(GITHUB_CREDENTIALS_PATH).touch()
         
     return github_config


### PR DESCRIPTION
The first time you run git config it tries to open the credentials file using:
`open(~file_path~, 'r')`
Which errors if the file does not exist.

Fix: open the file once during the get_or_create function
